### PR TITLE
Create directory before writing file in _writeFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kindle-periodical",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "create a periodical .mobi, with kindlegen",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "author": "Michael Röber",
   "license": "MIT",
   "dependencies": {
-    "underscore": "^1.7.0",
-    "when": "^3.4.5",
+    "html-minifier": "^0.6.8",
+    "mkdirp": "^0.5.1",
     "sanitize-html": "^1.3.0",
-    "html-minifier": "^0.6.8"
+    "underscore": "^1.7.0",
+    "when": "^3.4.5"
   }
 }

--- a/src/kindle-periodical.js
+++ b/src/kindle-periodical.js
@@ -9,6 +9,7 @@
     var sanitizeHtml    = require('sanitize-html');
     var minify          = require('html-minifier').minify;
     var exec            = require('child_process').exec;
+    var mkdirp          = require('mkdirp');
 
     var tempDir         = path.resolve(__dirname, '../', 'temp');
     var kindlegenPath   = null; // null will use $PATH
@@ -53,9 +54,13 @@
     function _writeFile(filename, content) {
 
         return when.promise(function(resolve, reject) {
-            fs.writeFile(filename, content, { encoding : 'utf8' }, function(err) {
+            mkdirp(path.dirname(filename), function (err) {
                 if (err) reject(err);
-                else resolve();
+
+                fs.writeFile(filename, content, { encoding : 'utf8' }, function(err) {
+                    if (err) reject(err);
+                    else resolve();
+                });
             });
         });
     }


### PR DESCRIPTION
Node seems to be throwing an `ENOENT` error when it tries to write files to the `temp` directory because it does not yet exist. Use `mkdirp` to create the directory before writing temporary files. Should fix #2.
