### PR TITLE
Encoding fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,14 @@ Kindlegen must **NOT** be in PATH, will be downloaded on install!
 
 ### CLI usage
     kindle-periodical -f nameOfBook /path/to/.json
-    
-    -f --filename   name of created .mobi
-    -o --output     folder of created .mobi
+
+    -f --filename           name of created .mobi
+    -o --output             folder of created .mobi
+    --maxImageWidth         maximal width image will be resized to
+    --maxImageHeight        maximal height image will be resized to
+    --saveImageGrayscale    images will be converted to grayscale
+    --saveImageJpeg         images of all formats will be saved as jpeg
+
 
 will create a ```compiled``` folder with the generated book
 
@@ -47,7 +52,7 @@ will create a ```compiled``` folder with the generated book
             }]
         }]
     };
-    
+
     periodical.create(bookData, {
         targetFolder: '.' // where should the mobi file go
     })

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ will create a ```compiled``` folder with the generated book
         "sections"      : [{
             "title" : 'title-of-section',
             "articles"  : [{
-                "title"  : 'title-of-article',
-                "author" : 'author-of-article',
-                "content": 'content-of-article'
-                "file"   : "path-to-local-file",
-                "url"    : 'url-to-a-website'
+                "title"    : 'title-of-article',
+                "author"   : 'author-of-article',
+                "content"  : 'content-of-article',
+                "markdown" : 'is-content-markdown',
+                "file"     : "path-to-local-file",
+                "url"      : 'url-to-a-website'
             }]
         }]
     };

--- a/cmd.js
+++ b/cmd.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+const { exit } = require('process');
+
 (() => {
     'use strict';
 
@@ -8,10 +11,23 @@
 
     let filename = argv.filename || argv.f || null;
     let targetFolder = argv.output || argv.o || null;
+    let maxImageWidth = argv.maxImageWidth || null;
+    let maxImageHeight = argv.maxImageHeight || null;
+    let saveImageGrayscale = argv.saveImageGrayscale || false;
+    let saveImageJpeg = argv.saveImageJpeg || false;
 
     let opts = {};
     if (filename) opts.filename = filename;
     if (targetFolder) opts.targetFolder = targetFolder;
+    if (maxImageWidth) opts.maxImageWidth = maxImageWidth;
+    if (maxImageHeight) opts.maxImageHeight = maxImageHeight;
+    if (saveImageGrayscale) opts.saveImageGrayscale = saveImageGrayscale;
+    if (saveImageJpeg) opts.saveImageJpeg = saveImageJpeg;
+
+    if ((maxImageWidth && !maxImageHeight) || (maxImageHeight && !maxImageWidth)) {
+        console.log('Parameters maxImageWidth and maxImageHeight has to be set both or none.');
+        exit();
+    }
 
     let bookData = JSON.parse(fs.readFileSync(argv._[0], 'utf8'));
     kindlePeriodical.create(bookData, opts);

--- a/src/file.js
+++ b/src/file.js
@@ -64,7 +64,7 @@
         // create folder if not exists
         await this.createFolder(bookFolderPath);
 
-        return fs.writeFile(path.join(bookFolderPath, fileName), fileContent, 'latin1');
+        return fs.writeFile(path.join(bookFolderPath, fileName), fileContent, 'utf8');
     };
 
     exports.cleanupBookFolder = function () {

--- a/src/kindle-periodical.js
+++ b/src/kindle-periodical.js
@@ -38,9 +38,6 @@
     async function checkContent (content, article) {
         content = content.toString();
 
-        // convert markdown
-        content = converter.makeHtml(content);
-
         // remove not supported tags
         content = sanitizeHtml(content, {
             allowedTags      : mobiSupportedTags,
@@ -113,7 +110,7 @@
 
             let fileName = `${sectionNumber}-${pad(articleNumber)}.html`;
 
-            let content = article.content || '';
+            let content = article.content || undefined;
             if (article.url) {
                 try {
                     content = await RemoteHandler.readRemoteContent(article.url);
@@ -121,8 +118,12 @@
                     console.log(`fail to read remote ( ${article.url} ) content: ${err.message}`);
                 }
             }
-            if (article.file) {
+            else if (article.file) {
                 content = await readFile(article.file);
+            }
+
+            if (article.markdown) {
+                content = converter.makeHtml(content);
             }
 
             console.log(`-> create article (HTML) with Name ${fileName}`);

--- a/src/kindle-periodical.js
+++ b/src/kindle-periodical.js
@@ -35,7 +35,7 @@
         return (`00000${value}`).slice(-5);
     }
 
-    async function checkContent (content, article) {
+    async function checkContent (content, article, opts) {
         content = content.toString();
 
         // remove not supported tags
@@ -70,7 +70,7 @@
             content = `<body>${content}</body>`;
         }
 
-        content = await RemoteHandler.readRemoteImagesFromContent(content, article);
+        content = await RemoteHandler.readRemoteImagesFromContent(content, article, opts);
 
         return content;
     }
@@ -79,7 +79,7 @@
         return new Promise((resolve, reject) => {
             let commands = [
                 'cd ' + path.normalize(bookFolderPath),
-                `${path.resolve(__dirname, '..', 'bin/kindlegen')} -c2 contents.opf -o ${filename}.mobi`
+                `${path.resolve(__dirname, '..', 'bin/kindlegen')} -c2 contents.opf -o ${filename}.mobi -gif`
             ];
 
             let kindlegenExec = exec(commands.join(' && '));
@@ -103,7 +103,7 @@
         await FileHandler.copyFile(createdMobiPath, compiledMobiPath);
     }
 
-    async function createArticleHTMLFiles (article, articleNumber, sectionNumber) {
+    async function createArticleHTMLFiles (article, articleNumber, sectionNumber, opts) {
         try {
             assert.ok(typeof sectionNumber === 'number', 'sectionNumber is no number');
             assert.ok(typeof articleNumber === 'number', 'articleNumber is no number');
@@ -127,7 +127,7 @@
             }
 
             console.log(`-> create article (HTML) with Name ${fileName}`);
-            const checkedContent = await checkContent(content, article);
+            const checkedContent = await checkContent(content, article, opts);
             await FileHandler.writeToBookFolder(fileName, checkedContent);
 
             return fileName;
@@ -137,7 +137,7 @@
         }
     }
 
-    async function createSections (availableSections = []) {
+    async function createSections (availableSections = [], opts) {
         assert.ok(availableSections, 'no sections given');
 
         // get template data
@@ -155,7 +155,8 @@
                 let createdFileName = await createArticleHTMLFiles(
                     article,
                     parseInt(articleIndex, 10),
-                    parseInt(sectionIndex, 10)
+                    parseInt(sectionIndex, 10),
+                    opts
                 );
 
                 articles.push($article({
@@ -314,7 +315,7 @@
                 await FileHandler.copyFile(params.cover, path.join(bookFolderPath, path.basename(params.cover)));
             }
 
-            let createdSections = await createSections(params.sections);
+            let createdSections = await createSections(params.sections, opts);
             await createContentHTMLFile(createdSections);
             await createOpfHTMLFile(params);
             await createNsxHTMLFile(params);

--- a/src/kindle-periodical.js
+++ b/src/kindle-periodical.js
@@ -111,7 +111,7 @@
             let fileName = `${sectionNumber}-${pad(articleNumber)}.html`;
 
             let content = article.content || undefined;
-            if (article.url) {
+            if (article.url && !content) {
                 try {
                     content = await RemoteHandler.readRemoteContent(article.url);
                 } catch (err) {
@@ -132,7 +132,7 @@
 
             return fileName;
         } catch (err) {
-            console.log('fail to create HTML for Article');
+            console.log(`fail to create HTML for Article: ${article.url}`);
             throw Error(err);
         }
     }

--- a/src/kindle-periodical.js
+++ b/src/kindle-periodical.js
@@ -49,6 +49,18 @@
             }
         });
 
+        content = content.replace(/data-src/g, 'src');
+        content = content.replace(/<source>/g, '<source/>');
+        content = content.replace(/<img>/g, '');
+
+        if ((content.split('<body>').length - 1) === 0) {
+            content = `<body>${content}</body>`;
+        }
+
+        if ((content.split('<head>').length - 1) === 0) {
+            content = `<head><meta content="text/html; charset=utf-8" http-equiv="Content-Type"/></head>${content}`;
+        }
+
         // minify html
         content = minify(content, {
             collapseWhitespace       : true,
@@ -61,14 +73,6 @@
             minifyCSS                : true,
             removeRedundantAttributes: true
         });
-
-        content = content.replace(/data-src/g, 'src');
-        content = content.replace(/<source>/g, '<source/>');
-        content = content.replace(/<img>/g, '');
-
-        if ((content.split('<body>').length - 1) === 0) {
-            content = `<body>${content}</body>`;
-        }
 
         content = await RemoteHandler.readRemoteImagesFromContent(content, article, opts);
 

--- a/src/remote.js
+++ b/src/remote.js
@@ -76,20 +76,22 @@
     }
 
     async function guessExtension(imageFilename) {
+        console.log(`Guessing extension for: ${imageFilename}`);
         let extension = '';
-        await jimp.read(imageFilename)
-            .then((image) => {
-                console.log(image.getMIME());
-                try {
-                    if (image.getMIME() === jimp.MIME_PNG) {
-                        extension = '.png';
-                    } else if (image.getMIME() === jimp.MIME_JPEG) {
-                        extension = '.jpg';
-                    }
-                } catch (err) {
-                    console.log(`Error when guessing extension: ${err}`);
-                }
-            });
+        try {
+            await jimp.read(imageFilename)
+                .then((image) => {
+                        const mime = image.getMIME();
+                        console.log(`MIME: ${mime}`);
+                        if (mime === jimp.MIME_PNG) {
+                            extension = '.png';
+                        } else if (mime === jimp.MIME_JPEG) {
+                            extension = '.jpg';
+                        }
+                });
+        } catch (err) {
+            console.log(`Error when guessing extension: ${err}`);
+        }
 
         return extension;
     }
@@ -108,6 +110,11 @@
 
                 let cleanedFileName = cleanedBaseName + extension;
                 let cleanedImagePath = path.join(process.cwd(), 'book', cleanedFileName);
+
+                // some webservers use lazy loading of images
+                if (img['data-src']) {
+                    img.src = img['data-src'];
+                }
 
                 // check if absolute url, try to fix if not
                 if (!isAbsoluteUrl(img.src)) {

--- a/src/remote.js
+++ b/src/remote.js
@@ -161,14 +161,16 @@
         // get content from url
         const dom = await JSDOM.fromURL(url);
 
-        // add a utf8 header
-        dom.window.document.head.insertAdjacentHTML('beforeend', '<meta charset="ISO-8859-1">');
-
         // simplify
         const reader = new readability(dom.window.document);
         const article = reader.parse();
 
+        var content = new JSDOM(article.content);
+
+        // add a utf8 header
+        content.window.document.head.insertAdjacentHTML('beforeend', '<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>');
+
         // return content
-        return article.content;
+        return content.serialize();
     };
 })();

--- a/src/remote.js
+++ b/src/remote.js
@@ -67,7 +67,10 @@
                     }
 
                     if (opts.saveImageGrayscale) {
-                        image.grayscale();
+                        image.color([
+                            { apply: 'greyscale', params: [16] }  // kindle reader has 16 gray levels
+                        ]);
+                        image.normalize();
                     }
 
                     if (mime === jimp.MIME_JPEG || opts.saveImageJpeg) {


### PR DESCRIPTION
I suggest to use UTF-8 encoding throughout whole process. The latin1 encoding did not worked for me in case of remote content fetching.
I changed file-saving to use UTF-8 and add `meta` tag to the cleaned document, so `kindlegen` undestands it correctly.